### PR TITLE
Facebook and database account email duplicate fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,3 +57,6 @@ gem 'devise'
 
 # enable user to authenticate by facebook
 gem 'omniauth-facebook'
+
+# send email using Sendgrid
+gem 'sendgrid-ruby'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,6 +182,7 @@ GEM
       rubocop (>= 0.72.0)
     ruby-progressbar (1.10.1)
     ruby_dep (1.5.0)
+    ruby_http_client (3.3.0)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -193,6 +194,8 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    sendgrid-ruby (6.0.0)
+      ruby_http_client (~> 3.3.0)
     slim (4.0.1)
       temple (>= 0.7.6, < 0.9)
       tilt (>= 2.0.6, < 2.1)
@@ -253,6 +256,7 @@ DEPENDENCIES
   rails (~> 6.0.0)
   rubocop-rails
   sass-rails (~> 5)
+  sendgrid-ruby
   slim-rails
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,15 +8,15 @@ class User < ApplicationRecord
 
   def self.new_with_session(params, session)
     super.tap do |user|
-      if session['devise.facebook_data'] && session['devise.facebook_data']['extra']['raw_info']
+      if session['devise.facebook_data'].present? && session['devise.facebook_data']['extra']['raw_info'].present?
         user.email = session['devise.facebook_data']['extra']['raw_info']['email'] if user.email.blank?
       end
     end
   end
 
   def self.from_omniauth(auth)
-    if where(email: auth.info.email).exists?
-      user = find_by(email: auth.info.email)
+    user = find_by(email: auth.info.email)
+    if user.present?
       user.update(provider: auth.provider, uid: auth.uid)
     else
       user = create do |u|

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,25 +15,17 @@ class User < ApplicationRecord
   end
 
   def self.from_omniauth(auth)
-    # where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
-    #   user.email = auth.info.email
-    #   user.password = Devise.friendly_token[0, 20]
-    # end
     if where(email: auth.info.email).exists?
-      byebug
-      return_user = find_by(email: auth.info.email)
-      # return_user.provider = auth.provider
-      # return_user.uid = auth.uid
-      return_user.update_attributes(provider: auth.provider, uid: auth.uid)
+      user = find_by(email: auth.info.email)
+      user.update(provider: auth.provider, uid: auth.uid)
     else
-      byebug
-      return_user = create do |user|
-        user.provider = auth.provider
-        user.uid = auth.uid
-        user.email = auth.info.email
-        user.password = Devise.friendly_token[0, 20]
+      user = create do |u|
+        u.provider = auth.provider
+        u.uid = auth.uid
+        u.email = auth.info.email
+        u.password = Devise.friendly_token[0, 20]
       end
     end
-    return_user
+    user
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,19 +4,36 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,
          :omniauthable, omniauth_providers: %i[facebook]
+  validates :email, uniqueness: true
 
   def self.new_with_session(params, session)
     super.tap do |user|
-      if data == session['devise.facebook_data'] && session['devise.facebook_data']['extra']['raw_info']
-        user.email = data['email'] if user.email.blank?
+      if session['devise.facebook_data'] && session['devise.facebook_data']['extra']['raw_info']
+        user.email = session['devise.facebook_data']['extra']['raw_info']['email'] if user.email.blank?
       end
     end
   end
 
   def self.from_omniauth(auth)
-    where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
-      user.email = auth.info.email
-      user.password = Devise.friendly_token[0, 20]
+    # where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
+    #   user.email = auth.info.email
+    #   user.password = Devise.friendly_token[0, 20]
+    # end
+    if where(email: auth.info.email).exists?
+      byebug
+      return_user = find_by(email: auth.info.email)
+      # return_user.provider = auth.provider
+      # return_user.uid = auth.uid
+      return_user.update_attributes(provider: auth.provider, uid: auth.uid)
+    else
+      byebug
+      return_user = create do |user|
+        user.provider = auth.provider
+        user.uid = auth.uid
+        user.email = auth.info.email
+        user.password = Devise.friendly_token[0, 20]
+      end
     end
+    return_user
   end
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -29,10 +29,10 @@ development:
   # To create additional roles in postgres see `$ createuser --help`.
   # When left blank, postgres will use the default role. This is
   # the same name as the operating system user that initialized the database.
-  username: owen
+  username: <%= ENV.fetch("PG_USER_NAME") %>
 
   # The password associated with the postgres role (username).
-  password: owen
+  password: <%= ENV.fetch("PG_USER_PASSWORD") %>
 
   # Connect on a TCP socket. Omitted by default since the client uses a
   # domain socket that doesn't need configuration. Windows does not have
@@ -58,8 +58,8 @@ development:
 test:
   <<: *default
   database: blog_assignment_test
-  username: owen
-  pass: owen
+  username: <%= ENV.fetch("PG_USER_NAME") %>
+  password: <%= ENV.fetch("PG_USER_PASSWORD") %>
   port: 5432
   host: localhost
 # As with config/credentials.yml, you never want to store sensitive information,


### PR DESCRIPTION
# Issue

Facebook email and database existed account with duplicate email

# Descriptions

- Handle when user A create account with  email X, then login with Facebook whose Facebook email is also X leading to duplicate to the user A account email. https://github.com/owen-le-goldenowl/blog-assignment/commit/bcaf0b3c33ee266ec510a3e67b3ebdd1a334e0f4#diff-4676c008b11a5480d73d4a6de01e45b9

- Decide to use Sendgrid for email sending

- Hide database.yml credentials use ENV variables
