### PR TITLE
fix css lost when signup fail or reset password reset fail

### DIFF
--- a/app/javascript/packs/stylesheets/users/users_passwords_new.scss
+++ b/app/javascript/packs/stylesheets/users/users_passwords_new.scss
@@ -1,41 +1,41 @@
-.passwords-new-view {
+.passwords-new-view, .passwords-create-view {
 
-    background-color: #f8f8f8;
+  background-color: #f8f8f8;
 
-    .main {
-        background: #f8f8f8;
-        padding: 150px 0;
+  .main {
+    background: #f8f8f8;
+    padding: 150px 0;
 
-        .container {
-            padding-top: 150px;
-            margin-bottom: 150px;
+    .container {
+      padding-top: 150px;
+      margin-bottom: 150px;
 
-            .new-password-content {
-                box-shadow: 0px 15px 16.83px 0.17px rgba(0, 0, 0, 0.05);
-                border-radius: 20px;
-                padding: 75px 0;
+      .new-password-content {
+        box-shadow: 0px 15px 16.83px 0.17px rgba(0, 0, 0, 0.05);
+        border-radius: 20px;
+        padding: 75px 0;
 
-                .new-password-form {
-                    padding-left: 110px;
+        .new-password-form {
+          padding-left: 110px;
 
-                    @media only screen and (max-width: 991.98px) {
-                        padding: 0 1.5rem !important;
-                    }
+          @media only screen and (max-width: 991.98px) {
+            padding: 0 1.5rem !important;
+          }
 
-                    .form-control {
-                        margin-bottom: 2rem;
-                    }
+          .form-control {
+            margin-bottom: 2rem;
+          }
 
-                    h2 {
-                        margin-bottom: 33px;
-                        font-size: 36px;
-                    }
-                }
-
-                img {
-                    padding: 40px;
-                }
-            }
+          h2 {
+            margin-bottom: 33px;
+            font-size: 36px;
+          }
         }
+
+        img {
+          padding: 40px;
+        }
+      }
     }
+  }
 }

--- a/app/javascript/packs/stylesheets/users/users_registrations_new.scss
+++ b/app/javascript/packs/stylesheets/users/users_registrations_new.scss
@@ -1,4 +1,4 @@
-.registrations-new-view {
+.registrations-new-view, .registrations-create-view {
 
   background-color: #f8f8f8;
 

--- a/app/javascript/packs/stylesheets/users/users_sessions_new.scss
+++ b/app/javascript/packs/stylesheets/users/users_sessions_new.scss
@@ -1,40 +1,40 @@
 .sessions-new-view {
-    background-color: #f8f8f8;
+  background-color: #f8f8f8;
 
-    .main {
-        background: #f8f8f8;
-        padding: 150px 0;
+  .main {
+    background: #f8f8f8;
+    padding: 150px 0;
 
-        .container {
-            padding-top: 150px;
-            margin-bottom: 150px;
+    .container {
+      padding-top: 150px;
+      margin-bottom: 150px;
 
-            .login-content {
-                box-shadow: 0px 15px 16.83px 0.17px rgba(0, 0, 0, 0.05);
-                border-radius: 20px;
-                padding: 75px 0;
+      .login-content {
+        box-shadow: 0px 15px 16.83px 0.17px rgba(0, 0, 0, 0.05);
+        border-radius: 20px;
+        padding: 75px 0;
 
-                .login-form {
-                    padding-right: 110px;
+        .login-form {
+          padding-right: 110px;
 
-                    @media only screen and (max-width: 991.98px) {
-                        padding: 0 1.5rem !important;
-                    }
+          @media only screen and (max-width: 991.98px) {
+            padding: 0 1.5rem !important;
+          }
 
-                    h2 {
-                        margin-bottom: 33px;
-                        font-size: 36px;
-                    }
+          h2 {
+            margin-bottom: 33px;
+            font-size: 36px;
+          }
 
-                    .form-control {
-                        margin-bottom: 2rem;
-                    }
+          .form-control {
+            margin-bottom: 2rem;
+          }
 
-                    img {
-                        padding: 40px;
-                    }
-                }
-            }
+          img {
+            padding: 40px;
+          }
         }
+      }
     }
+  }
 }

--- a/app/views/devise/registrations/new.html.slim
+++ b/app/views/devise/registrations/new.html.slim
@@ -1,7 +1,7 @@
 h2
   | Sign up
 = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
-  = render "devise/shared/error_messages", resource: resource
+  = render "users/shared/error_messages", resource: resource
   .field
     = f.label :email
     br

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -1,4 +1,16 @@
-div [class='main' ]
+- flash.each do |key, value|
+  - if key == 'notice'
+    div [class="alert alert-success fade show text-center"]
+      strong = value
+      button [type='button' data-dismiss='alert' class='close' aria-label="close" ]
+        span [aria-hidden="true" ] &times;
+  - elsif key == 'alert'
+    div [class="alert alert-danger fade show text-center"]
+      strong = value
+      button [type='button' data-dismiss='alert' class='close' aria-label="close" ]
+        span [aria-hidden="true" ] &times;
+
+div [class='main']
   h1 [class='text-center'] Blog homepage
   - if user_signed_in?
     = link_to 'Log out', destroy_user_session_path,method: :delete

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -8,7 +8,6 @@ html
     meta name="viewport" content="width=device-width,initial-scale=1"
     = stylesheet_pack_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
-    script src="https://kit.fontawesome.com/1b32ad5942.js" crossorigin="anonymous"
+    / script src="https://kit.fontawesome.com/1b32ad5942.js" crossorigin="anonymous"
   body class="#{controller_name}-#{action_name}-view"
-    = render 'layouts/messages'
     = yield

--- a/app/views/users/passwords/new.html.slim
+++ b/app/views/users/passwords/new.html.slim
@@ -4,7 +4,7 @@
       .new-password-form.col-sm-12.col-md-6
         h2.text-center.mt-3.pt-2 Forgot your password?
         = form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
-          = render "devise/shared/error_messages", resource: resource
+          = render "users/shared/error_messages", resource: resource
           .form-group
             = f.email_field :email, autofocus: true, autocomplete: "email", placeholder: 'Account email', class: 'form-control'
           .form-group.text-center

--- a/app/views/users/registrations/new.html.slim
+++ b/app/views/users/registrations/new.html.slim
@@ -4,7 +4,7 @@
       .register-form.col-sm-12.col-md-6
         h2.text-center.mt-3.pt-2 Sign up
         = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
-          = render "devise/shared/error_messages", resource: resource
+          = render "users/shared/error_messages", resource: resource
           .form-group
             = f.email_field :email, autofocus: true, autocomplete: "email", class: 'form-control', placeholder: 'Email'
           .form-group

--- a/app/views/users/sessions/new.html.slim
+++ b/app/views/users/sessions/new.html.slim
@@ -8,6 +8,7 @@
       .login-form.col-sm-12.col-md-6
         h2.text-center.mt-3.pt-2 Log in
         = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
+          = render 'layouts/messages'
           .form-group
             = f.email_field :email, autofocus: true, autocomplete: "email", class: 'form-control', placeholder: 'Email'
           .form-group

--- a/app/views/users/shared/_error_messages.html.slim
+++ b/app/views/users/shared/_error_messages.html.slim
@@ -1,10 +1,19 @@
 - if resource.errors.any?
-  #error_explanation
-    h2
-      = I18n.t("errors.messages.not_saved",
-      -                  count: resource.errors.count,
-      -                  resource: resource.class.model_name.human.downcase)
-    ul
-      - resource.errors.full_messages.each do |message|
-        li
-          = message
+  - resource.errors.full_messages.each do |message|
+    .alert.alert-danger.alert-dismissible.fade.show role='alert'
+      strong = message
+      button type='button' class='close' data-dismiss='alert' aria-label='Close'
+        span [aria-hidden='true']  &times;
+
+/ - if resource.errors.any?
+/   #error_explanation.alert.alert-danger.alert-dismissible.fade.show role='alert'
+/     h2.alert-heading
+/       = I18n.t("errors.messages.not_saved",
+/               count: resource.errors.count,
+/               resource: resource.class.model_name.human.downcase)
+/     ul
+/       - resource.errors.full_messages.each do |message|
+/         li
+/           = message
+/     button type='button' class='close' data-dismiss='alert' aria-label='Close'
+/       span [aria-hidden='true']  &times;


### PR DESCRIPTION
# Issue

When fail to signup or reset password, the app render a new route and make css lost.

# Descriptions

1. fix the issue

2. move error messages to the form instead of very first of the page

# Pictures

![show errors in login view](https://user-images.githubusercontent.com/54341400/66388493-78d29400-e9f0-11e9-9b64-a9fe5b422b1f.png)

![show errors in sign up view](https://user-images.githubusercontent.com/54341400/66388523-85ef8300-e9f0-11e9-9756-d40ec2001576.png)

![show errors in password reset view](https://user-images.githubusercontent.com/54341400/66388546-94d63580-e9f0-11e9-97f9-2f90ffc44a4a.png)